### PR TITLE
Fixes bug on scroll

### DIFF
--- a/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
+++ b/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
@@ -50,7 +50,7 @@ public class RecyclerViewMatcher {
                     RecyclerView recyclerView =
                         (RecyclerView) view.getRootView().findViewById(recyclerViewId);
                     if (recyclerView != null && recyclerView.getId() == recyclerViewId) {
-                        childView = recyclerView.getChildAt(position);
+                        childView = recyclerView.findViewHolderForAdapterPosition(position).itemView;
                     }
                     else {
                         return false;


### PR DESCRIPTION
getChildAt returns null if the recyclerview scrolls

I think ```findViewHolderForAdapterPosition(position).itemView``` is more elegant solution and its working perfect