### PR TITLE
Change RecyclerViewMatcher description

### DIFF
--- a/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
+++ b/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
@@ -29,7 +29,8 @@ public class RecyclerViewMatcher {
 
             public void describeTo(Description description) {
                 String idDescription = Integer.toString(recyclerViewId);
-                if (this.resources != null) {
+				String targetIdDescription = Integer.toString(targetViewId);
+				if (this.resources != null) {
                     try {
                         idDescription = this.resources.getResourceName(recyclerViewId);
                     } catch (Resources.NotFoundException var4) {
@@ -37,9 +38,23 @@ public class RecyclerViewMatcher {
                                                       new Object[] { Integer.valueOf
                                                           (recyclerViewId) });
                     }
+
+					if (targetViewId != -1) {
+						try {
+							targetIdDescription = this.resources.getResourceName(targetViewId);
+						} catch (Resources.NotFoundException var4) {
+							idDescription = String.format("%s (resource name not found)",
+									new Object[]{Integer.valueOf
+											(targetViewId)});
+						}
+					} else {
+						targetIdDescription = "none";
+					}
                 }
 
-                description.appendText("with id: " + idDescription);
+				description.appendText(" with id: " + idDescription
+						+ " ,and target view Id: " + targetIdDescription
+						+ " at position: " + position);
             }
 
             public boolean matchesSafely(View view) {


### PR DESCRIPTION
Action: Changed matcher description to contain targetViewId and position
Reason: When the matcher fails to find targetViewId, the description
 message for the failure is not clear as it only shows that it didn't
 find the recyclerView, while in fact it did find the recyclerView but
 didn't find the targetView at the specified position

I was creating my own UI test and the description message was confusing for me, since the problem was related to the targetView's position not the recycler view.
hope this will help others avoid the confusion